### PR TITLE
add -fPIC to args used for compiling the hdll

### DIFF
--- a/src/hxscript/setup/Native.hx
+++ b/src/hxscript/setup/Native.hx
@@ -179,7 +179,7 @@ class Native {
 		if (!FileSystem.exists(into))
 			FileSystem.createDirectory(into);
 
-		var args:Array<String> = ['-shared', '-fvisibility=hidden'];
+		var args:Array<String> = ['-shared', '-fvisibility=hidden', '-fPIC'];
 		for (a in shared(carried, headers))
 			args.push(a);
 


### PR DESCRIPTION
fixes the following error which can apparently happen:
```
Warning : hxscript: compiled scripts need a native module and the module did not compile
/usr/bin/ld.bfd: /tmp/cc6NQcFA.o: relocation R_X86_64_32 against symbol `hlt_i32' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld.bfd: failed to set dynamic section sizes: bad value collect2: error: ld returned 1 exit status
Until then every script is interpreted, which is a slower program rather than a broken one.
```